### PR TITLE
Refine splash and language selection design

### DIFF
--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="?android:colorBackground" />
+    <item>
+        <shape android:shape="rectangle">
+            <gradient
+                android:type="linear"
+                android:startColor="#FF6B6B"
+                android:endColor="#4ECDC4"
+                android:angle="45" />
+        </shape>
+    </item>
 
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
+    <item>
         <bitmap
             android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+            android:src="@mipmap/ic_launcher" />
+    </item>
 </layer-list>

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/white" />
+    <item>
+        <shape android:shape="rectangle">
+            <gradient
+                android:type="linear"
+                android:startColor="#FF6B6B"
+                android:endColor="#4ECDC4"
+                android:angle="45" />
+        </shape>
+    </item>
 
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
+    <item>
         <bitmap
             android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+            android:src="@mipmap/ic_launcher" />
+    </item>
 </layer-list>

--- a/lib/presentation/modules/authen_module/language_selection/src/ui/language_selection_screen.dart
+++ b/lib/presentation/modules/authen_module/language_selection/src/ui/language_selection_screen.dart
@@ -127,11 +127,22 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen> with 
 
   void _continueToOnboarding() async {
     await Globals.prefs.setBool(SharedPrefsKey.language_selected, true);
-    
+
     CustomNavigator.pushReplacement(
       context,
       OnboardingScreen(),
       animationType: AnimationType.slide,
+    );
+  }
+
+  Widget _buildDecorCircle(Color color) {
+    return Container(
+      width: 160,
+      height: 160,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
     );
   }
 
@@ -259,23 +270,36 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen> with 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [
-              AppColors.mint.withValues(alpha: 0.3),
-              AppColors.lavender.withValues(alpha: 0.2),
-              Colors.white,
-            ],
+      body: Stack(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  AppColors.coral.withValues(alpha: 0.2),
+                  AppColors.sunnyYellow.withValues(alpha: 0.2),
+                  AppColors.mint.withValues(alpha: 0.2),
+                ],
+              ),
+            ),
           ),
-        ),
-        child: SafeArea(
-          child: FadeTransition(
-            opacity: _fadeAnimation,
-            child: Column(
-              children: [
+          Positioned(
+            top: -60,
+            left: -60,
+            child: _buildDecorCircle(AppColors.coral.withValues(alpha: 0.3)),
+          ),
+          Positioned(
+            bottom: -80,
+            right: -80,
+            child: _buildDecorCircle(AppColors.mint.withValues(alpha: 0.3)),
+          ),
+          SafeArea(
+            child: FadeTransition(
+              opacity: _fadeAnimation,
+              child: Column(
+                children: [
                 const SizedBox(height: 40),
                 // Header
                 Padding(

--- a/lib/presentation/modules/authen_module/splash/src/ui/splash_screen.dart
+++ b/lib/presentation/modules/authen_module/splash/src/ui/splash_screen.dart
@@ -149,13 +149,27 @@ class _SplashScreenState extends State<SplashScreen> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               const Spacer(),
-              Container(
-                child: CustomIconSplashAnimation(
-                  iconPath: Assets.iconApp,
-                  size: 250.0,
+              CustomIconSplashAnimation(
+                iconPath: Assets.iconApp,
+                size: 250.0,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                AppLocalizations.text(LangKey.app_name),
+                style: const TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black87,
                 ),
               ),
-              const SizedBox(height: 40),
+              const SizedBox(height: 8),
+              const Text(
+                'Your AI companion',
+                style: TextStyle(
+                  fontSize: 16,
+                  color: Colors.black54,
+                ),
+              ),
               const Spacer(),
               CustomLoadingIndicator(
                 effectType: LoadingEffectType.bouncingDots,


### PR DESCRIPTION
## Summary
- Add vibrant gradient and centered logo to Android launch background for a more attractive splash.
- Introduce app name and tagline on the Flutter splash screen.
- Refresh language selection screen with playful gradient and decorative circles.

## Testing
- `flutter test` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_6896c9f1411c832d85a1a3de50515919